### PR TITLE
COMP: Rename project name to match extension name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(VideoCameras)
+project(SlicerVideoCameras)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
By renaming the project name, it ensures the project name is consistent
with the extension name added to the Slicer ExtensionsIndex and will
ensure extension configured with -DSlicerVideoCameras_DIR:PATH=/path/to/build
can successfully find the associated configuration.